### PR TITLE
[Feat] 사업자 인증 메일 API 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-loader-tools'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 
 	//jwt
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'

--- a/src/main/java/com/likelion/bizup/global/enums/ValidateState.java
+++ b/src/main/java/com/likelion/bizup/global/enums/ValidateState.java
@@ -1,0 +1,17 @@
+package com.likelion.bizup.global.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum ValidateState {
+    VALID("인증 성공"),
+    VALID_YET("인증 전"),
+    NOW_VALIDATING("인증 중"),
+    NON_VALID("인증 실패");
+
+    private final String value;
+
+    ValidateState(String value){
+        this.value = value;
+    }
+}

--- a/src/main/java/com/likelion/bizup/global/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/likelion/bizup/global/error/handler/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.likelion.bizup.global.error.handler;
 
+import com.likelion.bizup.module.jwt.exception.TokenException;
 import java.util.Objects;
 
 import org.springframework.http.HttpStatus;
@@ -27,6 +28,19 @@ public class GlobalExceptionHandler {
 	// AppException > 서비스 기능 제공 내에서 난 에러인 경우 해당 핸들러를 이용하여 에러 처리
 	@ExceptionHandler(AppException.class)
 	public ResponseEntity<ResponseDto> exceptionHandler(AppException e) {
+		int code = e.getErrorCode().getHttpStatus().value();
+		String message = e.getMessage();
+
+		// 내부 서버 에러일 경우, stack trace 출력
+		if (code == 500)
+			e.printStackTrace();
+
+		return ResponseEntity.status(code).body(ResponseDto.of(code, message));
+	}
+
+	// AppException > JWT 인증 중 Filter 에서 난 에러인 경우 해당 핸들러를 이용하여 에러 처리
+	@ExceptionHandler(TokenException.class)
+	public ResponseEntity<ResponseDto> exceptionHandler(TokenException e) {
 		int code = e.getErrorCode().getHttpStatus().value();
 		String message = e.getMessage();
 

--- a/src/main/java/com/likelion/bizup/global/util/RandomUtil.java
+++ b/src/main/java/com/likelion/bizup/global/util/RandomUtil.java
@@ -1,0 +1,22 @@
+package com.likelion.bizup.global.util;
+
+import java.security.SecureRandom;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+public class RandomUtil {
+
+    private static final int CODE_LENGTH = 6;
+    private static final SecureRandom random = new SecureRandom();
+
+    public static String generateCode() {
+        StringBuilder codeBuilder = new StringBuilder();
+        for (int i = 0; i < CODE_LENGTH; i++) {
+            int digit = random.nextInt(10);
+            codeBuilder.append(digit);
+        }
+        return codeBuilder.toString();
+    }
+}

--- a/src/main/java/com/likelion/bizup/infra/smtp/MailService.java
+++ b/src/main/java/com/likelion/bizup/infra/smtp/MailService.java
@@ -1,0 +1,10 @@
+package com.likelion.bizup.infra.smtp;
+
+
+public interface MailService {
+
+    void sendVerificationCode(String sendTo, String code);
+
+
+    void send(String sendTo, String subject, String content);
+}

--- a/src/main/java/com/likelion/bizup/infra/smtp/SimpleMailService.java
+++ b/src/main/java/com/likelion/bizup/infra/smtp/SimpleMailService.java
@@ -1,0 +1,50 @@
+package com.likelion.bizup.infra.smtp;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class SimpleMailService implements MailService {
+
+    private static final String VERIFICATION_EMAIL_TITLE = "[Bizup] 사업자 번호 인증코드";
+
+    private final JavaMailSender mailSender;
+
+    public SimpleMailService(JavaMailSender mailSender) {
+        this.mailSender = mailSender;
+    }
+
+    @Override
+    public void sendVerificationCode(String sendTo, String code) {
+        String content = buildVerificationEmailContent(code);
+        send(sendTo, VERIFICATION_EMAIL_TITLE, content);
+    }
+
+    @Override
+    public void send(String sendTo, String subject, String content){
+
+        System.setProperty("mail.debug", "true");
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+            helper.setTo(sendTo);
+            helper.setSubject(subject);
+            helper.setText(content, true);
+
+            mailSender.send(message);
+            log.info("메일 발송 성공: To: {}, Subject: {}", sendTo, subject);
+        } catch (MessagingException e) {
+            log.error("메일 발송 실패: {}", e.getMessage(), e);
+        }
+    }
+
+    private String buildVerificationEmailContent(String code) {
+        return "<html><body>안녕하세요.<br>Bizup의 사업자 등록 인증 메일입니다.<br><br>인증번호는 <b>" + code + "</b> 입니다.</body></html>";
+    }
+}

--- a/src/main/java/com/likelion/bizup/module/jwt/TokenStatusCode.java
+++ b/src/main/java/com/likelion/bizup/module/jwt/TokenStatusCode.java
@@ -1,13 +1,19 @@
 package com.likelion.bizup.module.jwt;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-@Getter
-@AllArgsConstructor
-public enum TokenStatusCode{
-    TOKEN_EXPIRED("만료된 JWT 토큰입니다."),
-    TOKEN_EMPTY("JWT 토큰이 비어있습니다."),
-    TOKEN_INVALID("유효하지 않은 JWT 토큰입니다.");
 
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum TokenStatusCode {
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "만료된 JWT 토큰입니다."),
+    TOKEN_EMPTY(HttpStatus.UNAUTHORIZED, "JWT 토큰이 비어있습니다."),
+    TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 JWT 토큰입니다.");
+
+    private final HttpStatus httpStatus;
     private final String message;
 
+    TokenStatusCode(HttpStatus httpStatus, String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
 }

--- a/src/main/java/com/likelion/bizup/module/user/UserStatusCode.java
+++ b/src/main/java/com/likelion/bizup/module/user/UserStatusCode.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum UserStatusCode implements StatusCode {
+    CODE_SIZE_ERROR(HttpStatus.BAD_REQUEST, "코드 사이즈가 일치하지 않습니다."),
     INVALIDATE_CODE(HttpStatus.FORBIDDEN, "코드 인증에 실패했습니다."),
     DUPLICATE_BNO(HttpStatus.CONFLICT, "이미 검증을 시도한 사업자 번호가 있습니다."),
     VALIDATE_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "검증 여부 이력이 없습니다."),

--- a/src/main/java/com/likelion/bizup/module/user/UserStatusCode.java
+++ b/src/main/java/com/likelion/bizup/module/user/UserStatusCode.java
@@ -6,6 +6,10 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum UserStatusCode implements StatusCode {
+    INVALIDATE_CODE(HttpStatus.FORBIDDEN, "코드 인증에 실패했습니다."),
+    DUPLICATE_BNO(HttpStatus.CONFLICT, "이미 검증을 시도한 사업자 번호가 있습니다."),
+    VALIDATE_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "검증 여부 이력이 없습니다."),
+    NON_VALIDATE_USER(HttpStatus.FORBIDDEN, "코드 검증이 필요합니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     DUPLICATE_USER(HttpStatus.CONFLICT, "이미 등록된 사용자입니다."),
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "입력 값이 유효하지 않습니다.");

--- a/src/main/java/com/likelion/bizup/module/user/controller/UserController.java
+++ b/src/main/java/com/likelion/bizup/module/user/controller/UserController.java
@@ -1,37 +1,46 @@
 package com.likelion.bizup.module.user.controller;
 
+import com.likelion.bizup.global.common.DataResponseDto;
+import com.likelion.bizup.global.common.ResponseDto;
 import com.likelion.bizup.global.error.GlobalStatusCode;
-import com.likelion.bizup.module.user.UserStatusCode;
 import com.likelion.bizup.global.error.exception.AppException;
-import com.likelion.bizup.module.user.exception.UserException;
 import com.likelion.bizup.module.jwt.dto.request.TokenRequestDto;
 import com.likelion.bizup.module.jwt.dto.response.AccessTokenResponseDto;
+import com.likelion.bizup.module.jwt.service.JwtTokenProvider;
+import com.likelion.bizup.module.user.UserStatusCode;
 import com.likelion.bizup.module.user.dto.request.LoginRequestDto;
 import com.likelion.bizup.module.user.dto.request.UserRegistrationDto;
+import com.likelion.bizup.module.user.dto.request.ValidateUserRequestDto;
 import com.likelion.bizup.module.user.dto.response.LoginResponseDto;
 import com.likelion.bizup.module.user.entity.User;
-import com.likelion.bizup.module.jwt.service.JwtTokenProvider;
+import com.likelion.bizup.module.user.exception.UserException;
 import com.likelion.bizup.module.user.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
 @RestController
 @RequestMapping("/api/users")
+@RequiredArgsConstructor
 public class UserController implements UserControllerDocs {
-    @Autowired
-    private UserService userService;
-    @Autowired
-    private JwtTokenProvider jwtTokenProvider;
+    private final UserService userService;
+    private final JwtTokenProvider jwtTokenProvider;
+
     @PostMapping("/register")
-    public ResponseEntity<?> registerUser(@RequestBody UserRegistrationDto dto) {
+    public ResponseEntity<ResponseDto> registerUser(@RequestBody UserRegistrationDto dto) {
         try {
-            User registeredUser = userService.registerUser(dto);
-            return new ResponseEntity<>(registeredUser, HttpStatus.CREATED);
-        } catch (IllegalArgumentException e) {
-            throw new UserException(UserStatusCode.DUPLICATE_USER, e.getMessage());
-        } catch (Exception e) {
-            throw new AppException(GlobalStatusCode.INTERNAL_SERVER_ERROR,e.getMessage());
+           userService.registerUser(dto);
+            return ResponseEntity.ok(ResponseDto.of(201));
+        } catch (UserException e) {
+            throw new AppException(UserStatusCode.DUPLICATE_USER, e.getMessage());
         }
     }
 
@@ -49,11 +58,14 @@ public class UserController implements UserControllerDocs {
             throw new AppException(GlobalStatusCode.INTERNAL_SERVER_ERROR, "로그인 처리 중 알 수 없는 오류가 발생했습니다.");
         }
     }
+
     @PostMapping("/renew")
     public ResponseEntity<?> renewAccessToken(@RequestBody TokenRequestDto tokenRequest) {
-        String newAccessToken = jwtTokenProvider.renewAccessToken(tokenRequest.getUserId(), tokenRequest.getRefreshToken());
+        String newAccessToken = jwtTokenProvider.renewAccessToken(tokenRequest.getUserId(),
+                tokenRequest.getRefreshToken());
         return ResponseEntity.ok(new AccessTokenResponseDto(newAccessToken));
     }
+
     @PostMapping("/logout")
     public ResponseEntity<String> logout(@RequestBody TokenRequestDto tokenRequest) {
         try {
@@ -62,5 +74,17 @@ public class UserController implements UserControllerDocs {
         } catch (IllegalArgumentException e) {
             return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
         }
+    }
+
+    @PostMapping("/validate")
+    public ResponseEntity<ResponseDto> createValidateUser(@RequestBody @Valid ValidateUserRequestDto validateUserReq) {
+         userService.createValidateUser(validateUserReq);
+        return ResponseEntity.ok(ResponseDto.of(201));
+    }
+
+    @GetMapping("/validate")
+    public ResponseEntity<ResponseDto> checkCodeValidate(@RequestParam("code") String code) {
+        Long validateUserId = userService.checkCodeValidate(code);
+        return ResponseEntity.status(200).body(DataResponseDto.of(validateUserId, 200));
     }
 }

--- a/src/main/java/com/likelion/bizup/module/user/controller/UserControllerDocs.java
+++ b/src/main/java/com/likelion/bizup/module/user/controller/UserControllerDocs.java
@@ -64,6 +64,7 @@ public interface UserControllerDocs {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "코드 인증 되었습니다. 다음 단계를 진행해주세요"),
             @ApiResponse(responseCode = "403", description = "코드 인증에 실패했습니다."),
+            @ApiResponse(responseCode = "404", description = "코드 사이즈가 일치하지 않습니다."),
             @ApiResponse(responseCode = "500", description = "내부 서버 오류가 발생했습니다.")
     })
     ResponseEntity<ResponseDto> checkCodeValidate(String code);

--- a/src/main/java/com/likelion/bizup/module/user/controller/UserControllerDocs.java
+++ b/src/main/java/com/likelion/bizup/module/user/controller/UserControllerDocs.java
@@ -4,47 +4,68 @@ import com.likelion.bizup.global.common.ResponseDto;
 import com.likelion.bizup.module.jwt.dto.request.TokenRequestDto;
 import com.likelion.bizup.module.user.dto.request.LoginRequestDto;
 import com.likelion.bizup.module.user.dto.request.UserRegistrationDto;
+import com.likelion.bizup.module.user.dto.request.ValidateUserRequestDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
+
 @Tag(name = "User API", description = "사용자의 정보를 저장, 로그인, 로그아웃, 토큰 갱신 등을 처리합니다.")
 public interface UserControllerDocs {
 
-	@Operation(summary = "회원가입 API", description = "아이디, 비밀번호, 사업자 정보를 기입합니다.")
-	@ApiResponses(value = {
-			@ApiResponse(responseCode = "201", description = "회원가입이 성공적으로 완료되었습니다."),
-			@ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
-			@ApiResponse(responseCode = "409", description = "중복된 사용자입니다."),
-			@ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.")
-	})
-	ResponseEntity<?> registerUser(@RequestBody UserRegistrationDto dto);
+    @Operation(summary = "회원가입 API", description = "아이디, 비밀번호, 사업자 정보를 기입합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "회원가입이 성공적으로 완료되었습니다."),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+            @ApiResponse(responseCode = "403", description = "검증된 사용자가 아닙니다."),
+            @ApiResponse(responseCode = "404", description = "검증 여부 이력이 없습니다."),
+            @ApiResponse(responseCode = "409", description = "중복된 사용자입니다."),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.")
+    })
+    ResponseEntity<?> registerUser(@RequestBody UserRegistrationDto dto);
 
-	@Operation(summary = "로그인 API", description = "사용자가 아이디와 비밀번호로 로그인합니다.")
-	@ApiResponses(value = {
-			@ApiResponse(responseCode = "200", description = "로그인 성공"),
-			@ApiResponse(responseCode = "401", description = "로그인 정보가 유효하지 않습니다."),
-			@ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.")
-	})
-	ResponseEntity<?> login(@RequestBody LoginRequestDto loginRequest);
+    @Operation(summary = "로그인 API", description = "사용자가 아이디와 비밀번호로 로그인합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "로그인 성공"),
+            @ApiResponse(responseCode = "401", description = "로그인 정보가 유효하지 않습니다."),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.")
+    })
+    ResponseEntity<?> login(@RequestBody LoginRequestDto loginRequest);
 
-	@Operation(summary = "Access Token 갱신 API", description = "Refresh Token을 이용하여 새로운 Access Token을 발급합니다.")
-	@ApiResponses(value = {
-			@ApiResponse(responseCode = "200", description = "Access Token 갱신 성공"),
-			@ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
-			@ApiResponse(responseCode = "401", description = "Refresh Token이 유효하지 않습니다."),
-			@ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.")
-	})
-	ResponseEntity<?> renewAccessToken(@RequestBody TokenRequestDto tokenRequest);
+    @Operation(summary = "Access Token 갱신 API", description = "Refresh Token을 이용하여 새로운 Access Token을 발급합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Access Token 갱신 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+            @ApiResponse(responseCode = "401", description = "Refresh Token이 유효하지 않습니다."),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.")
+    })
+    ResponseEntity<?> renewAccessToken(@RequestBody TokenRequestDto tokenRequest);
 
-	@Operation(summary = "로그아웃 API", description = "사용자의 Refresh Token을 삭제하고 로그아웃 처리합니다.")
-	@ApiResponses(value = {
-			@ApiResponse(responseCode = "200", description = "로그아웃 성공"),
-			@ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
-			@ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.")
-	})
-	ResponseEntity<String> logout(@RequestBody TokenRequestDto tokenRequest);
+    @Operation(summary = "로그아웃 API", description = "사용자의 Refresh Token을 삭제하고 로그아웃 처리합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "로그아웃 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.")
+    })
+    ResponseEntity<String> logout(@RequestBody TokenRequestDto tokenRequest);
+
+
+    @Operation(summary = "사업자 번호 메일 전송 API", description = "이메일과 사업자 번호를 받아 메일 전송을 처리합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "메일 전송되었습니다."),
+            @ApiResponse(responseCode = "409", description = "이미 검증을 시도한 사업자 번호가 있습니다."),
+            @ApiResponse(responseCode = "500", description = "내부 서버 오류가 발생했습니다.")
+    })
+    ResponseEntity<ResponseDto> createValidateUser(ValidateUserRequestDto validateUserReq);
+
+    @Operation(summary = "전송된 코드 인증 API", description = "전송된 코드에 따른 인증을 진행하고, 코드 인증 후, 받은 아이디를 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "코드 인증 되었습니다. 다음 단계를 진행해주세요"),
+            @ApiResponse(responseCode = "403", description = "코드 인증에 실패했습니다."),
+            @ApiResponse(responseCode = "500", description = "내부 서버 오류가 발생했습니다.")
+    })
+    ResponseEntity<ResponseDto> checkCodeValidate(String code);
 }
 

--- a/src/main/java/com/likelion/bizup/module/user/dto/request/UserRegistrationDto.java
+++ b/src/main/java/com/likelion/bizup/module/user/dto/request/UserRegistrationDto.java
@@ -8,6 +8,10 @@ import lombok.Getter;
 @AllArgsConstructor
 @Schema(description = "회원 등록 요청 DTO")
 public class UserRegistrationDto {
+
+    @Schema(description = "코드 인증 후, 받은 아이디", example = "1")
+    private long validateId;
+
     @Schema(description = "사용자 아이디", example = "user123")
     private String userid;
 

--- a/src/main/java/com/likelion/bizup/module/user/dto/request/ValidateUserRequestDto.java
+++ b/src/main/java/com/likelion/bizup/module/user/dto/request/ValidateUserRequestDto.java
@@ -1,0 +1,21 @@
+package com.likelion.bizup.module.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class ValidateUserRequestDto {
+    @Schema(description = "사업자 이메일", example = "business@swu.ac.kr")
+    @Email(message = "유효한 이메일 주소를 입력하세요.")
+    @NotBlank(message = "이메일을 입력하세요.")
+    private String email;
+
+    @Schema(description = "사업자 번호", example = "398-87-01116")
+    @Size(min = 12,max = 12,message = "사업자 번호는 12자여야 합니다.")
+    @Pattern(regexp = "^\\d{3}-\\d{2}-\\d{5}$", message = "사업자 번호 형식이 유효하지 않습니다.")
+    private String bno;
+}

--- a/src/main/java/com/likelion/bizup/module/user/entity/User.java
+++ b/src/main/java/com/likelion/bizup/module/user/entity/User.java
@@ -1,6 +1,7 @@
 package com.likelion.bizup.module.user.entity;
 import com.likelion.bizup.global.common.BaseTime;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -25,10 +26,15 @@ public class User extends BaseTime {
     private String accountNum;
     private String nickname;
 
+    @OneToOne
+    @JoinColumn(name = "validate_user_id")
+    private ValidateUser validateUser;
+
     @Builder
-    public User(String userid, String password, String phone, String businessName,String businessNum,
+    public User(@NotNull ValidateUser validateUser, String userid, String password, String phone, String businessName, String businessNum,
                 String businessAddress, String description,
                 String itemSendLocation, String accountNum, String nickname) {
+        this.validateUser = validateUser;
         this.userid = userid;
         this.password = password;
         this.phone = phone;

--- a/src/main/java/com/likelion/bizup/module/user/entity/ValidateUser.java
+++ b/src/main/java/com/likelion/bizup/module/user/entity/ValidateUser.java
@@ -1,0 +1,44 @@
+package com.likelion.bizup.module.user.entity;
+
+import com.likelion.bizup.global.common.BaseTime;
+import com.likelion.bizup.global.enums.ValidateState;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "validate_user")
+@Getter
+@NoArgsConstructor
+public class ValidateUser extends BaseTime {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String email;
+    private String bno;
+    private ValidateState state;
+    private String code;
+
+    @Builder
+    public ValidateUser(String email, String bno){
+        this.email = email;
+        this.bno = bno;
+        this.state = ValidateState.NOW_VALIDATING; // 현재는 인증 처리 단계가 없기에 우선 처리
+        this.code = null;
+    }
+
+    public void updateCode(String code){
+        this.code = code;
+    }
+
+
+    public void updateState(ValidateState state){
+        this.state = state;
+    }
+}

--- a/src/main/java/com/likelion/bizup/module/user/event/ValidateBnoEvent.java
+++ b/src/main/java/com/likelion/bizup/module/user/event/ValidateBnoEvent.java
@@ -1,0 +1,8 @@
+package com.likelion.bizup.module.user.event;
+
+import com.likelion.bizup.module.user.entity.ValidateUser;
+
+public record ValidateBnoEvent(
+        ValidateUser validateUser
+) {
+}

--- a/src/main/java/com/likelion/bizup/module/user/event/listener/ValidateBnoEventEventListener.java
+++ b/src/main/java/com/likelion/bizup/module/user/event/listener/ValidateBnoEventEventListener.java
@@ -1,0 +1,42 @@
+package com.likelion.bizup.module.user.event.listener;
+
+import com.likelion.bizup.global.util.RandomUtil;
+import com.likelion.bizup.infra.smtp.MailService;
+import com.likelion.bizup.module.user.entity.ValidateUser;
+import com.likelion.bizup.module.user.event.ValidateBnoEvent;
+import com.likelion.bizup.module.user.repository.ValidateUserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ValidateBnoEventEventListener {
+    private final MailService mailService;
+    private final ValidateUserRepository validateUserRepository;
+
+    @EventListener
+    public void handleSignedUpEvent(ValidateBnoEvent event) {
+        ValidateUser validateUser = event.validateUser();
+
+        // 인증 코드 생성 및 업데이트
+        String code = createValidateCode(validateUser);
+
+        // 인증 코드 이메일 발송
+        mailService.sendVerificationCode(validateUser.getEmail(), code);
+    }
+
+    private String createValidateCode(ValidateUser validateUser) {
+        // 중복되지 않는 코드 생성
+        String code;
+        do {
+            code = RandomUtil.generateCode();
+        } while (validateUserRepository.existsByCode(code));
+
+        // 코드 생성 및 저장
+        validateUser.updateCode(code);
+        validateUserRepository.save(validateUser);
+
+        return code;
+    }
+}

--- a/src/main/java/com/likelion/bizup/module/user/event/publisher/ValidateBnoEventEventPublisher.java
+++ b/src/main/java/com/likelion/bizup/module/user/event/publisher/ValidateBnoEventEventPublisher.java
@@ -1,0 +1,23 @@
+package com.likelion.bizup.module.user.event.publisher;
+
+import com.likelion.bizup.module.user.entity.ValidateUser;
+import com.likelion.bizup.module.user.event.ValidateBnoEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ValidateBnoEventEventPublisher {
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Async
+    public void publishSignedUpEvent(ValidateUser validateUser) {
+        eventPublisher.publishEvent(new ValidateBnoEvent(validateUser));
+
+        log.info("ValidateBnoEvent published asynchronously for validateUser ID: {}", validateUser.getId());
+    }
+}

--- a/src/main/java/com/likelion/bizup/module/user/repository/ValidateUserRepository.java
+++ b/src/main/java/com/likelion/bizup/module/user/repository/ValidateUserRepository.java
@@ -1,0 +1,11 @@
+package com.likelion.bizup.module.user.repository;
+
+import com.likelion.bizup.module.user.entity.ValidateUser;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ValidateUserRepository extends JpaRepository<ValidateUser, Long> {
+    Boolean existsByBno(String bno);
+    Boolean existsByCode(String Code);
+    Optional<ValidateUser> findByCode(String Code);
+}

--- a/src/main/java/com/likelion/bizup/module/user/service/UserService.java
+++ b/src/main/java/com/likelion/bizup/module/user/service/UserService.java
@@ -72,6 +72,8 @@ public class UserService {
 
     // 코드 인증 > 해당 validate 사용자 번호 반환
     public Long checkCodeValidate(String code) {
+        validateCodeSize(code);
+
         ValidateUser validateUser = validateUserRepository.findByCode(code).orElseThrow(
                 () -> new AppException(UserStatusCode.INVALIDATE_CODE)
         );
@@ -83,6 +85,7 @@ public class UserService {
 
         return validateUser.getId();
     }
+
 
     // 사업자 번호 확인 메일 발송
     public void createValidateUser(ValidateUserRequestDto validateUserReq) {
@@ -98,6 +101,12 @@ public class UserService {
         // 현재는 따로 인증 처리 진행하지 않기에 바로 이메일 발송으로 처리
         if (validateUser.getState() == ValidateState.NOW_VALIDATING) {
             validateBnoEventEventPublisher.publishSignedUpEvent(validateUser);
+        }
+    }
+
+    private static void validateCodeSize(String code) {
+        if(code.length() != 6){
+            throw new AppException(UserStatusCode.CODE_SIZE_ERROR);
         }
     }
 

--- a/src/main/java/com/likelion/bizup/module/user/service/UserService.java
+++ b/src/main/java/com/likelion/bizup/module/user/service/UserService.java
@@ -1,29 +1,45 @@
 package com.likelion.bizup.module.user.service;
 
-import com.likelion.bizup.module.user.UserStatusCode;
-import com.likelion.bizup.module.user.exception.UserException;
+import com.likelion.bizup.global.enums.ValidateState;
+import com.likelion.bizup.global.error.exception.AppException;
 import com.likelion.bizup.module.jwt.service.JwtTokenProvider;
+import com.likelion.bizup.module.user.UserStatusCode;
 import com.likelion.bizup.module.user.dto.request.UserRegistrationDto;
+import com.likelion.bizup.module.user.dto.request.ValidateUserRequestDto;
 import com.likelion.bizup.module.user.entity.User;
+import com.likelion.bizup.module.user.entity.ValidateUser;
+import com.likelion.bizup.module.user.event.publisher.ValidateBnoEventEventPublisher;
+import com.likelion.bizup.module.user.exception.UserException;
 import com.likelion.bizup.module.user.repository.UserRepository;
-import org.springframework.beans.factory.annotation.Autowired;
+import com.likelion.bizup.module.user.repository.ValidateUserRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class UserService {
-    @Autowired
-    private UserRepository userRepository;
-    @Autowired
-    private PasswordEncoder passwordEncoder;
-    @Autowired
-    private JwtTokenProvider jwtTokenProvider;
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final ValidateUserRepository validateUserRepository;
+    private final ValidateBnoEventEventPublisher validateBnoEventEventPublisher;
 
-    public User registerUser(UserRegistrationDto dto) {
+    public void registerUser(UserRegistrationDto dto) {
         if (userRepository.existsByUserid(dto.getUserid())) {
             throw new IllegalArgumentException("가입된 아이디가 존재합니다.");
         }
+
+        ValidateUser validateUser = validateUserRepository.findById(dto.getValidateId()).orElseThrow(
+                () -> new AppException(UserStatusCode.VALIDATE_USER_NOT_FOUND)
+        );
+
+        if (validateUser.getState() != ValidateState.VALID) {
+            throw new AppException(UserStatusCode.NON_VALIDATE_USER);
+        }
+
         User user = new User(
+                validateUser,
                 dto.getUserid(),
                 passwordEncoder.encode(dto.getPassword()),
                 dto.getPhone(),
@@ -35,8 +51,9 @@ public class UserService {
                 dto.getNickname(),
                 dto.getAccountNum()
         );
-        return userRepository.save(user);
+        userRepository.save(user);
     }
+
     public void validateUser(String userId, String rawPassword) {
         User user = userRepository.findByUserid(userId)
                 .orElseThrow(() -> new UserException(UserStatusCode.USER_NOT_FOUND));
@@ -44,10 +61,50 @@ public class UserService {
             throw new UserException(UserStatusCode.INVALID_INPUT, "비밀번호가 일치하지 않습니다.");
         }
     }
+
     public String createAccessToken(String userId) {
         return jwtTokenProvider.createAccessToken(userId, "ROLE_USER");
     }
+
     public String createRefreshToken(String userId) {
         return jwtTokenProvider.createRefreshToken(userId);
     }
+
+    // 코드 인증 > 해당 validate 사용자 번호 반환
+    public Long checkCodeValidate(String code) {
+        ValidateUser validateUser = validateUserRepository.findByCode(code).orElseThrow(
+                () -> new AppException(UserStatusCode.INVALIDATE_CODE)
+        );
+
+        // 다시 null 상태로 돌리기
+        validateUser.updateCode(null);
+        validateUser.updateState(ValidateState.VALID);
+        validateUserRepository.save(validateUser);
+
+        return validateUser.getId();
+    }
+
+    // 사업자 번호 확인 메일 발송
+    public void createValidateUser(ValidateUserRequestDto validateUserReq) {
+        // 사업자 번호 중복 검사
+        validateBnoUnique(validateUserReq);
+
+        // 인증 시도 이력 생성
+        ValidateUser validateUser = validateUserRepository.save(ValidateUser.builder()
+                .email(validateUserReq.getEmail())
+                .bno(validateUserReq.getBno())
+                .build());
+
+        // 현재는 따로 인증 처리 진행하지 않기에 바로 이메일 발송으로 처리
+        if (validateUser.getState() == ValidateState.NOW_VALIDATING) {
+            validateBnoEventEventPublisher.publishSignedUpEvent(validateUser);
+        }
+    }
+
+    private void validateBnoUnique(ValidateUserRequestDto validateUserReq) {
+        if (validateUserRepository.existsByBno(validateUserReq.getBno())) {
+            throw new AppException(UserStatusCode.DUPLICATE_BNO);
+        }
+    }
+
 }


### PR DESCRIPTION
## 🎟️ 관련 이슈
Resolves #13 

## 📑 Description
- 사업자 인증 메일 전송 API 추가
- 메일 코드 인증 API 추가
- 회원가입 상에 인증된 사용자인지 확인하는 로직 추가

## 📌 To Do
관련 task 모두 완료하였습니다.
다만 배포 시 추가해줘야 하는 설정들이 있을 수 있어 해당 부분 보완할 예정입니다.

## 💬 Comment